### PR TITLE
feat: add Analytics link to Sidebar and comment out Profile Dashboard Card

### DIFF
--- a/app/components/SideBar/Sidebar.tsx
+++ b/app/components/SideBar/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   FaPaintBrush,
   FaFolderPlus,
   FaSignOutAlt,
+  FaChartBar,
 } from "react-icons/fa";
 import Link from "next/link";
 import SignOutButton from "../SignOutButton";
@@ -21,6 +22,11 @@ export default function Sidebar() {
       href: "/dashboard/add-project",
       label: "Add Project",
       icon: FaFolderPlus,
+    },
+    {
+      href: "/dashboard/analytics",
+      label: "Analytics",
+      icon: FaChartBar,
     },
   ];
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -31,12 +31,12 @@ export default function Dashboard() {
           href='/dashboard/settings'
           icon={<Settings size={40} />}
         />
-        <DashboardCard
+        {/* <DashboardCard
           title='Profile'
           description='Update your personal information'
           href='/dashboard/profile'
           icon={<User size={40} />}
-        />
+        /> */}
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request introduces a new "Analytics" section in the sidebar and removes the "Profile" card from the dashboard. The changes focus on enhancing navigation and simplifying the dashboard interface.

### Sidebar Enhancements:
* Added a new "Analytics" section to the sidebar, including a new icon (`FaChartBar`) and link to `/dashboard/analytics`. (`app/components/SideBar/Sidebar.tsx`, [[1]](diffhunk://#diff-01dd539a7621195360afb210760f0c1ec5a9b9e8eefa5dc28ddfe7ad70c01133R10) [[2]](diffhunk://#diff-01dd539a7621195360afb210760f0c1ec5a9b9e8eefa5dc28ddfe7ad70c01133R26-R30)

### Dashboard Simplification:
* Commented out the "Profile" card in the dashboard to remove its visibility, simplifying the dashboard layout. (`app/dashboard/page.tsx`, [app/dashboard/page.tsxL34-R39](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013L34-R39))