### PR TITLE
feat: add Analytics link to Dashboard navigation

### DIFF
--- a/app/components/Navbar/DashboardNav.tsx
+++ b/app/components/Navbar/DashboardNav.tsx
@@ -214,6 +214,17 @@ export default function DashboardNav() {
             </li>
             <li>
               <Link
+                href='/dashboard/analytics'
+                onClick={closeSidebar}
+                className={`block px-4 py-2 text-sm hover:bg-gray-700 hover:text-white ${isActive(
+                  "/dashboard/analytics"
+                )}`}
+              >
+                Analytics
+              </Link>
+            </li>
+            <li>
+              <Link
                 href='/settings'
                 onClick={closeSidebar}
                 className={`block px-4 py-2 text-sm hover:bg-gray-700 hover:text-white ${isActive(


### PR DESCRIPTION
This pull request introduces a small enhancement to the `DashboardNav` component in `app/components/Navbar/DashboardNav.tsx`. It adds a new navigation link for "Analytics" in the dashboard sidebar.